### PR TITLE
Units fixes.

### DIFF
--- a/check_disk.rb
+++ b/check_disk.rb
@@ -42,9 +42,9 @@ if using_performance_data
   value = percent.to_i
  performance_data= "#{perf_label}=#{value}#{uom};#{warning};#{critical};"
 end
-free_gb =  `df -hl | grep '#{disk}' | awk '{print $4}'`.chomp.chop.chop
-total_gb = `df -hl | grep '#{disk}' | awk '{print $2}'`.chomp.chop.chop
-output_text = "#{status} Free: #{percent.to_i}% #{free_gb}GB/#{total_gb}GB"
+free_space =  `df -hl | grep '#{disk}' | awk '{print $4}'`.chomp.chop
+total_space = `df -hl | grep '#{disk}' | awk '{print $2}'`.chomp.chop
+output_text = "#{status} Free: #{percent.to_i}% #{free_space}/#{total_space}"
 
 puts output_text + " | "+performance_data
 exit exit_code


### PR DESCRIPTION
Deleted the second .chop for the free_gb and total_gb, so that it doesn't cut off df -hl's units (Ki, Gi, Ti).
Deleted the GBs from output_text, as we shouldn't assume that everything is in GB.
Changed free_gb and total_gb to free_space and total_space, again no assumptions about units.
